### PR TITLE
Fixes encoding error setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from setuptools import setup
 
 about = {}
@@ -15,7 +17,7 @@ setup(
     version=about['__version__'],
     license=about['__license__'],
     description=about['__description__'],
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     author=about['__author__'],
     author_email=about['__author_email__'],


### PR DESCRIPTION
Got an error installing the readtime package on mi CI Server.

```
https://files.pythonhosted.org/packages/36/bc/563243f52a700a08db2cfc1f4b24aa74a4723799ad56a69fb0be5f3b61cf/readtime-1.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ayocjnwa/readtime/setup.py", line 18, in <module>
        long_description=open('README.md').read(),
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 477: ordinal not in range(128)
```

For some reason, the `open()` reads the `README.md` with the ascii code. I have no clue why this happens, but this pull requests fixes it.