### PR TITLE
Fix security warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4>=4.0.1
-markdown2>=1.4.0
+markdown2>=2.4.3
 pyquery>=1.2

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py33, py34, py35, py36, py37, py38, py39
 [testenv]
 deps = -rdev-requirements.txt
 commands = nosetests


### PR DESCRIPTION
[CVE-2018-5773](https://github.com/advisories/GHSA-p6h9-gw49-rqm4)

Bump  `markdown2` version to 2.4.3

And upgrade python versions to 3.7 | 3.8 | 3.9